### PR TITLE
Fix GitHub Pages deployment permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     - cron: "*/15 * * * *"
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- allow GitHub Actions to push static site by granting contents: write permission

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab77aca6bc832d96d90efc69b5e9d6